### PR TITLE
Consume api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "annotate"
 gem "bootstrap-sass"
 gem "devise"
 gem "draper"
+gem 'faraday'
 gem "haml-rails"
 gem "jquery-rails"
 gem "sass-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,6 @@ end
 
 group :test do
   gem "shoulda-matchers"
+  gem "webmock"
+  gem "vcr"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
       railties (>= 3.0.0)
     faker (1.8.7)
       i18n (>= 0.7)
+    faraday (1.1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     ffi (1.9.23)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -152,6 +155,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     msgpack (1.2.4)
+    multipart-post (2.1.1)
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -234,6 +238,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-graphviz (1.2.3)
     ruby-progressbar (1.9.0)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
@@ -301,6 +306,7 @@ DEPENDENCIES
   draper
   factory_bot_rails
   faker
+  faraday
   haml-rails
   jquery-rails
   letter_opener

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     choice (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    crack (0.4.4)
     crass (1.0.4)
     debug_inspector (0.0.3)
     devise (4.4.3)
@@ -122,6 +123,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    hashdiff (1.0.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -283,8 +285,13 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
     uniform_notifier (1.11.0)
+    vcr (6.0.0)
     warden (1.2.7)
       rack (>= 1.0)
+    webmock (3.10.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -323,6 +330,8 @@ DEPENDENCIES
   spring-commands-rspec
   sqlite3
   uglifier
+  vcr
+  webmock
 
 BUNDLED WITH
    1.16.1

--- a/app/apis/pairguru_api.rb
+++ b/app/apis/pairguru_api.rb
@@ -1,0 +1,9 @@
+class PairguruApi
+  API_ENDPOINT = 'https://pairguru-api.herokuapp.com/api/v1/'.freeze
+
+  def movie_details(title)
+    Rails.cache.fetch([:movie_details, title], expires_in: 24.hours) do
+      Faraday.get "#{API_ENDPOINT}/movies/#{title}"
+    end
+  end
+end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -6,7 +6,7 @@ class MoviesController < ApplicationController
   end
 
   def show
-    @movie = Movie.find(params[:id])
+    @movie = Movie.find(params[:id]).decorate
   end
 
   def send_info

--- a/app/decorators/movie_decorator.rb
+++ b/app/decorators/movie_decorator.rb
@@ -1,9 +1,33 @@
 class MovieDecorator < Draper::Decorator
   delegate_all
 
+  API_ENDPOINT = 'https://pairguru-api.herokuapp.com'.freeze
+
+  def plot
+    movie_data["plot"]
+  end
+
   def cover
-    "http://lorempixel.com/100/150/" +
+    if movie_data
+      API_ENDPOINT + movie_data["poster"]
+    else
+      "http://lorempixel.com/100/150/" +
       %w[abstract nightlife transport].sample +
       "?a=" + SecureRandom.uuid
+    end
+  end
+
+  def rating
+    movie_data["rating"]
+  end
+
+  def fetch_movie
+    pairguru_api = PairguruApi.new
+    response = pairguru_api.movie_details(title.gsub(" ", "%20"))
+    JSON.parse(response.body)
+  end
+
+  def movie_data
+    fetch_movie.dig("data", "attributes")
   end
 end

--- a/app/views/movies/_movies_table.html.haml
+++ b/app/views/movies/_movies_table.html.haml
@@ -4,7 +4,7 @@
       %tr
         %td= i + 1
         %td
-          %img.img-rounded{ src: movie.cover }
+          %img.img-rounded{ src: movie.cover, width: 150 }
         %td
           %h4
             = link_to movie.title, movie_path(movie)
@@ -12,4 +12,8 @@
             %strong
               = link_to movie.genre.name, movies_genre_path(movie.genre)
             = ' (' + movie.released_at.to_s + ')'
-          %p= movie.description
+          %p
+            %strong
+              Rating
+            %span.rating= movie.rating
+          %p.plot= movie.plot

--- a/app/views/movies/show.html.haml
+++ b/app/views/movies/show.html.haml
@@ -1,5 +1,17 @@
-%h1= @movie.title
-.jumbotron
-  = @movie.description
-- if user_signed_in?
-  %p= link_to 'Email me details about this movie', send_info_movie_path(@movie), class: 'btn btn-sm btn-default'
+.container-fluid
+  .row
+    .col-md-3
+      .row
+        .col-xs-12
+          .thumbnail
+            %img.img-rounded{ src: @movie.cover }
+            .caption
+              %h1= @movie.title
+              %strong Rating
+              %span.rating= @movie.rating
+    .col-md-9
+      .row
+      .jumbotron
+        .lead= @movie.plot
+      - if user_signed_in?
+        %p= link_to 'Email me details about this movie', send_info_movie_path(@movie), class: 'btn btn-sm btn-default'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,8 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
+  config.cache_store = :null_store
+
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {

--- a/spec/external_apis/pairguru_api_spec.rb
+++ b/spec/external_apis/pairguru_api_spec.rb
@@ -4,15 +4,19 @@ describe 'PairguruApi' do
   let(:client) { PairguruApi.new }
 
   it "returns success status" do
-    response = client.movie_details("Kill%20Bill")
-    expect(response.status).to eq(200)
+    VCR.use_cassette('kill_bill') do
+      response = client.movie_details("Kill%20Bill")
+      expect(response.status).to eq(200)
+    end
   end
 
   it "returns movie details" do
     movie_title = "Kill Bill"
-    response = client.movie_details(movie_title.gsub(" ", "%20"))
-    json_body = JSON.parse(response.body)
-    expect(json_body).to be_an_instance_of(Hash)
-    expect(json_body).to include("data" => a_hash_including("attributes" => a_hash_including("title" => movie_title)))
+    VCR.use_cassette('kill_bill') do
+      response = client.movie_details(movie_title.gsub(" ", "%20"))
+      json_body = JSON.parse(response.body)
+      expect(json_body).to be_an_instance_of(Hash)
+      expect(json_body).to include("data" => a_hash_including("attributes" => a_hash_including("title" => movie_title)))
+    end
   end
 end

--- a/spec/external_apis/pairguru_api_spec.rb
+++ b/spec/external_apis/pairguru_api_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe 'PairguruApi' do
+  let(:client) { PairguruApi.new }
+
+  it "returns success status" do
+    response = client.movie_details("Kill%20Bill")
+    expect(response.status).to eq(200)
+  end
+
+  it "returns movie details" do
+    movie_title = "Kill Bill"
+    response = client.movie_details(movie_title.gsub(" ", "%20"))
+    json_body = JSON.parse(response.body)
+    expect(json_body).to be_an_instance_of(Hash)
+    expect(json_body).to include("data" => a_hash_including("attributes" => a_hash_including("title" => movie_title)))
+  end
+end

--- a/spec/factories/movie.rb
+++ b/spec/factories/movie.rb
@@ -1,6 +1,8 @@
+MOVIES = ["Kill Bill", "Django", "Kill Bill 2"]
+
 FactoryBot.define do
   factory :movie do
-    title { Faker::Lorem.word }
+    title { MOVIES.sample}
     description { Faker::Lorem.sentence(3, true) }
     released_at { Faker::Date.between(40.years.ago, Time.zone.today) }
     genre

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require "pry"
 require "capybara/rails"
 require "simplecov"
 require "shoulda/matchers"
+
 SimpleCov.start "rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -23,11 +24,12 @@ SimpleCov.start "rails"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/requests/genres_spec.rb
+++ b/spec/requests/genres_spec.rb
@@ -5,8 +5,24 @@ describe "Genres requests", type: :request do
 
   describe "genre list" do
     it "displays only related movies" do
+      stub_request(:get, /pairguru-api.herokuapp.com/).to_return(body: mock_data.to_json, status: 200)
       visit "/genres/" + genres.sample.id.to_s + "/movies"
       expect(page).to have_selector("table tr", count: 5)
     end
   end
+end
+
+private
+def mock_data
+  { "data" =>
+    { "id" => "3",
+      "type" => "movie",
+      "attributes" => {
+        "title" => "Kill Jill",
+        "plot" => "The Bride wakens from a four-year coma. The child she carried in her womb is gone. Now she must wreak vengeance on the team of assassins who betrayed her - a team she was once part of.",
+        "rating" => 8.1,
+        "poster" => "/kill_bill.jpg"
+      }
+    }
+  }
 end

--- a/spec/requests/movies_spec.rb
+++ b/spec/requests/movies_spec.rb
@@ -2,9 +2,30 @@ require "rails_helper"
 
 describe "Movies requests", type: :request do
   describe "movies list" do
+    before { create_list(:movie, 5) }
+
     it "displays right title" do
       visit "/movies"
       expect(page).to have_selector("h1", text: "Movies")
+    end
+
+    it "displays the rating for each movie" do
+      visit "/movies"
+      expect(page).to have_selector('.rating', count: 5)
+    end
+  end
+
+  describe "movie show" do
+    let(:movie) { create(:movie) }
+
+    it "displays the movie rating" do
+      visit "/movies/#{movie.id}"
+      expect(page).to have_selector('.rating')
+    end
+
+    it "displays the movie title" do
+      visit "/movies/#{movie.id}"
+      expect(page).to have_content(movie.title)
     end
   end
 end

--- a/spec/requests/movies_spec.rb
+++ b/spec/requests/movies_spec.rb
@@ -2,7 +2,10 @@ require "rails_helper"
 
 describe "Movies requests", type: :request do
   describe "movies list" do
-    before { create_list(:movie, 5) }
+    before(:each) do
+      create_list(:movie, 5)
+      stub_request(:get, /pairguru-api.herokuapp.com/).to_return(body: mock_data.to_json, status: 200)
+    end
 
     it "displays right title" do
       visit "/movies"
@@ -16,6 +19,9 @@ describe "Movies requests", type: :request do
   end
 
   describe "movie show" do
+    before(:each) do
+      stub_request(:get, /pairguru-api.herokuapp.com/).to_return(body: mock_data.to_json, status: 200)
+    end
     let(:movie) { create(:movie) }
 
     it "displays the movie rating" do
@@ -28,4 +34,19 @@ describe "Movies requests", type: :request do
       expect(page).to have_content(movie.title)
     end
   end
+end
+
+private
+def mock_data
+  { "data" =>
+    { "id" => "3",
+      "type" => "movie",
+      "attributes" => {
+        "title" => "Kill Jill",
+        "plot" => "The Bride wakens from a four-year coma. The child she carried in her womb is gone. Now she must wreak vengeance on the team of assassins who betrayed her - a team she was once part of.",
+        "rating" => 8.1,
+        "poster" => "/kill_bill.jpg"
+      }
+    }
+  }
 end

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -1,0 +1,6 @@
+require "vcr"
+
+VCR.configure do |c|
+  c.cassette_library_dir = "spec/vcr"
+  c.hook_into :webmock
+end

--- a/spec/validators/title_brackets_validator_spec.rb
+++ b/spec/validators/title_brackets_validator_spec.rb
@@ -1,4 +1,4 @@
-# require "rails_helper"
+require "rails_helper"
 
 describe TitleBracketsValidator do
   subject { Validatable.new(title: title) }

--- a/spec/vcr/kill_bill.yml
+++ b/spec/vcr/kill_bill.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pairguru-api.herokuapp.com/api/v1//movies/Kill%20Bill
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 18 Nov 2020 13:41:19 GMT
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"376c9c7ed832eb9a3f461d44a5f32f26"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 77c54b84-d6fa-4bb3-b90c-d547b10d4fde
+      X-Runtime:
+      - '0.013998'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"3","type":"movie","attributes":{"title":"Kill Bill","plot":"The
+        Bride wakens from a four-year coma. The child she carried in her womb is gone.
+        Now she must wreak vengeance on the team of assassins who betrayed her - a
+        team she was once part of.","rating":8.1,"poster":"/kill_bill.jpg"}}}'
+  recorded_at: Wed, 18 Nov 2020 13:41:20 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## What

Consume API data to sit alongside movie data from internal models. This cannot be stored in the database.

## How

Making use of the below gems, implement an API class to fetch movie data from the 'pairguru' api. 

- Faraday (http client)
- Webmock (stub api responses)
- VCR (record live api response)

Data is retrieved via the PairguruApi class using Faraday. This is presented through the current Movie decorator. I'm not certain this is the best place to deal with these interactions, but it works whilst I'm considering different solutions.

Tests have been implemented to test the live API using VCR to record a successful data response, whilst reducing test speed down the line. It would be beneficial to clear the cassettes periodically to ensure a working API.

Where tests are more concerned on the view, I have stubbed the responses using Webmock. 

To ensure quick responses in a production environment, the API call has been wrapped in a cache block which expires every 24 hours.