### PR TITLE
Build api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "5.2"
 
+gem 'active_model_serializers', '~> 0.10.0'
 gem "annotate"
 gem "bootstrap-sass"
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.0)
       activesupport (= 5.2.0)
       globalid (>= 0.3.6)
@@ -78,6 +83,8 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.0)
+    case_transform (0.2)
+      activesupport
     choice (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -136,6 +143,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    jsonapi-renderer (0.2.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.6.0)
@@ -302,6 +310,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   annotate
   better_errors
   binding_of_caller

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,6 @@
+module Api
+  module V1
+    class ApiController < ActionController::Base
+    end
+  end
+end

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    class MoviesController < ApiController
+      def show
+        @movie = Movie.find(params[:id])
+        render json: @movie, status: 200
+      end
+
+      def index
+        @movies = Movie.all
+        render json: @movies, status: 200
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -1,0 +1,6 @@
+module Api
+  module V2
+    class ApiController < ActionController::Base
+    end
+  end
+end

--- a/app/controllers/api/v2/movies_controller.rb
+++ b/app/controllers/api/v2/movies_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V2
+    class MoviesController < ApiController
+      def show
+        @movie = Movie.find(params[:id])
+        render json: @movie, include: ['genre'], status: 200
+      end
+
+      def index
+        @movies = Movie.all
+        render json: @movies, status: 200
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/movie_serializer.rb
+++ b/app/serializers/api/v1/movie_serializer.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class MovieSerializer < ActiveModel::Serializer
+      attributes :id, :title
+    end
+  end
+end

--- a/app/serializers/api/v2/genre_serializer.rb
+++ b/app/serializers/api/v2/genre_serializer.rb
@@ -1,0 +1,12 @@
+module Api
+  module V2
+    class GenreSerializer < ActiveModel::Serializer
+      attributes :id, :name, :movie_count
+      has_many :movies
+
+      def movie_count
+        object.movies.count
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/movie_serializer.rb
+++ b/app/serializers/api/v2/movie_serializer.rb
@@ -1,0 +1,8 @@
+module Api
+  module V2
+    class MovieSerializer < ActiveModel::Serializer
+      attributes :id, :title
+      belongs_to :genre
+    end
+  end
+end

--- a/config/initializers/active_model_serializer.rb
+++ b/config/initializers/active_model_serializer.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json_api

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,10 @@ Rails.application.routes.draw do
       get :export
     end
   end
+
+  namespace :api do
+    namespace :v1 do
+      resources :movies, only: [:index, :show]
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,9 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :movies, only: [:index, :show]
     end
+
+    namespace :v2 do
+      resources :movies, only: [:index, :show]
+    end
   end
 end

--- a/spec/external_apis/pairguru_api_spec.rb
+++ b/spec/external_apis/pairguru_api_spec.rb
@@ -4,7 +4,7 @@ describe 'PairguruApi' do
   let(:client) { PairguruApi.new }
 
   it "returns success status" do
-    VCR.use_cassette('kill_bill') do
+    VCR.use_cassette('kill_bill', :re_record_interval => 7.days) do
       response = client.movie_details("Kill%20Bill")
       expect(response.status).to eq(200)
     end
@@ -12,7 +12,7 @@ describe 'PairguruApi' do
 
   it "returns movie details" do
     movie_title = "Kill Bill"
-    VCR.use_cassette('kill_bill') do
+    VCR.use_cassette('kill_bill', :re_record_interval => 7.days) do
       response = client.movie_details(movie_title.gsub(" ", "%20"))
       json_body = JSON.parse(response.body)
       expect(json_body).to be_an_instance_of(Hash)

--- a/spec/requests/api/v1/movies_spec.rb
+++ b/spec/requests/api/v1/movies_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe 'Api::V1::Movies' do
+  describe 'GET /api/v1/movies' do
+    before do
+      create_list(:movie, 5)
+      get '/api/v1/movies'
+    end
+
+    it 'returns a success status' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns a list of movies' do
+      movies = response.parsed_body["data"]
+
+      expect(movies.length).to eq(5)
+    end
+  end
+
+  describe 'GET /api/v1/movies/:id' do
+    let(:movie) { create(:movie) }
+
+    it 'returns a success status' do
+      get "/api/v1/movies/#{movie.id}"
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns the correct attributes' do
+      get "/api/v1/movies/#{movie.id}"
+
+      movie = response.parsed_body["data"]
+
+      expect(movie).to include("id", "type")
+      expect(movie["attributes"]).to include("title")
+    end
+  end
+end

--- a/spec/requests/api/v2/movies_spec.rb
+++ b/spec/requests/api/v2/movies_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe 'Api::V2::Movies' do
+  describe 'GET /api/v2/movies' do
+    before do
+      create_list(:movie, 5)
+      get '/api/v2/movies'
+    end
+
+    it 'returns a success status' do
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it 'returns a list of movies' do
+      movies = response.parsed_body["data"]
+
+      expect(movies.length).to eq(5)
+    end
+  end
+
+  describe 'GET /api/v2/movies/:id' do
+    let(:movie) { create(:movie) }
+
+    it 'returns a success status' do
+      get "/api/v2/movies/#{movie.id}"
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns the correct attributes' do
+      get "/api/v2/movies/#{movie.id}"
+
+      movie_json = response.parsed_body["data"]
+
+      expect(movie_json).to include("id", "type")
+      expect(movie_json["attributes"]).to include("title")
+    end
+
+    it 'returns information regarding genre' do
+      get "/api/v2/movies/#{movie.id}"
+
+      expect(response.parsed_body).to include("data", "included")
+
+      expected = {
+        "included" => a_collection_including(
+          a_hash_including(
+            "attributes" => a_hash_including(
+              "name" => movie.genre.name,
+              "movie-count" => movie.genre.movies.count
+            )
+          )
+        )
+      }
+
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+end

--- a/spec/vcr/kill_bill.yml
+++ b/spec/vcr/kill_bill.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Wed, 18 Nov 2020 13:41:19 GMT
+      - Wed, 18 Nov 2020 15:50:50 GMT
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -37,9 +37,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 77c54b84-d6fa-4bb3-b90c-d547b10d4fde
+      - d097cbe8-c537-4da4-99b0-cf134d00e0b5
       X-Runtime:
-      - '0.013998'
+      - '0.004895'
       Transfer-Encoding:
       - chunked
       Via:
@@ -50,5 +50,5 @@ http_interactions:
         Bride wakens from a four-year coma. The child she carried in her womb is gone.
         Now she must wreak vengeance on the team of assassins who betrayed her - a
         team she was once part of.","rating":8.1,"poster":"/kill_bill.jpg"}}}'
-  recorded_at: Wed, 18 Nov 2020 13:41:20 GMT
+  recorded_at: Wed, 18 Nov 2020 15:50:50 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
## What

Implement API to return movie results. Initial implementation returning title and id of the movie. Extend into V2 for genre information.

## How

API controller and routes created using versioning to allow for future updates without breaking changes. In order to provide an API response which implements 'JSON:API', the ActiveModelSerializers gem (AMS) was used. 

A valid response could have been built with jbuilder, however such a gem makes implementing JSON:API simpler and less error prone. There were other options such as 'jsonapi-serializer', which arguably would be preferable as they are better maintained currently. However, having experience with AMS, this one was chosen.

The initial V1 api supplies the user with the title and id of movies. V2 builds on top of this to include the Genre relationship and how many movies are contained within the included genre without supplying users of V1 with the extra data.

Tests for each version have also been separated into their own versions.